### PR TITLE
feat: 增加公用目录配置 文件未匹配时尝试读取短横线命名文件

### DIFF
--- a/Config.ts
+++ b/Config.ts
@@ -3,6 +3,8 @@ import * as path from 'path'
 import Utils from './utils'
 
 const I18N_PATHS_KEY = 'i18nPaths'
+const I18N_COMMON_PATH_KEY = 'i18nCommonPath'
+const FILENAME_TO_KEBAB_CASE = 'filenameToKebabCase'
 
 export default class Config {
   static extAuthor: string
@@ -29,6 +31,16 @@ export default class Config {
       path.resolve(rootPath, pathItem)
     )
   }
+
+  static get i18nCommonPath() {
+    const rootPath = vscode.workspace.rootPath
+    const commonPath = this.getConfig(I18N_COMMON_PATH_KEY)
+    return path.resolve(rootPath, commonPath)
+  }
+
+  static get filenameToKebabCase() {
+    return this.getConfig(FILENAME_TO_KEBAB_CASE)
+  }  
 
   static get version() {
     return this.extension.packageJSON.version

--- a/commands/extract.ts
+++ b/commands/extract.ts
@@ -4,7 +4,7 @@ import meta from '../meta'
 import * as path from 'path'
 import { i18nFile } from '../i18nFile'
 import Config from '../Config'
-import { StructureType } from '../i18nFile/I18nItem'
+import { StructureType, MatchMode } from '../i18nFile/I18nItem'
 
 const toCamelCase = str => {
   return str.replace(/(-\w)/g, $1 => {
@@ -78,7 +78,7 @@ const onExtract = async ({
   })
 
   // 翻译内容
-  let transData = i18n.getI18n(key)
+  let transData = i18n.getI18n(key, MatchMode.WRITE)
   const mainTrans = transData.find(item => item.lng === Config.sourceLocale)
 
   mainTrans.text = text

--- a/i18nFile/I18nFile.ts
+++ b/i18nFile/I18nFile.ts
@@ -2,9 +2,22 @@ import * as vscode from 'vscode'
 import * as path from 'path'
 import Config from '../Config'
 import { I18nItem } from './I18nItem'
+import Log from '../Log'
 
 class I18nFile {
   i18nItems = new Map<String, I18nItem>()
+
+  constructor() {
+    const i18nCommonPath = Config.i18nCommonPath
+    // 如果设置了 common 目录
+    if (i18nCommonPath) {
+      try {
+        this.i18nItems.set(i18nCommonPath, new I18nItem(i18nCommonPath))
+      } catch (err) {
+        Log.error(err)
+      }
+    }
+  }
 
   getFileByFilepath(filepath: string): I18nItem {
     const localepath = this.getRelativePathByFilepath(filepath)

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -19,4 +19,7 @@ export default class Utils {
       ? ((Array.isArray(result) ? result[0] : result) as string)
       : undefined
   }
+  static camelToKabeb(str: string) {
+    return str.replace(/([A-Z])/g, "-$1").toLowerCase()
+  }  
 }


### PR DESCRIPTION
为了解决两个问题
1. 项目中有子项目的i18n合并了crm下的i18n，插件目前是就近查找i18n文件，在子项目的locales文件夹下找不到翻译项，导致无法识别。因此增加了一个公用目录配置，如果找不到，就到该共用目录下查找。
2. 项目中存在i18n键和文件命名不匹配的情况，i18n键用的是驼峰命名，文件名使用短横线命名。这种情况vue-i18n可以识别，但是插件目前无法识别。